### PR TITLE
Renamed macros assert and declare

### DIFF
--- a/srfi-145.html
+++ b/srfi-145.html
@@ -40,9 +40,6 @@ produce better code and to issue better warnings about dead code.
 <ul>
   <li>Can the title of this SRFI be improved?</li>
   <li>Is <code>fatal-error</code> a good name?</li>
-  <li>The names <code>assert</code> and <code>declare</code></li> are
-  already in use in non-standard extensions of some Schemes.  Are
-  there good alternatives to these names for this SRFI?
 </ul>
 
 <h1>Rationale</h1>
@@ -102,7 +99,8 @@ in non-debug situations:
   (cond-expand
     (debug
      (unless (exact-integer? x)
-       (error "f: argument is not an integer" x))))
+       (error "f: argument is not an integer" x)))
+    (else #f))
   (g (* x x)))
 </pre>
 
@@ -145,7 +143,7 @@ syntactic sugar.  The definition can also be rewritten as:</p>
 
 <pre>
 (define (f x)
-  (assert (exact-integer? x))
+  (assume (exact-integer? x))
   (g (* x x)))
 </pre>
 
@@ -155,7 +153,7 @@ Or as:
 
 <pre>
 (define (f x)
-  (declare (exact-integer? x))
+  (assume-type exact-integer? x)
   (g (* x x)))
 </pre>
 
@@ -233,13 +231,13 @@ not an error, only evaluation of such an expression is an error.</i>
 <h2>Syntax</h2>
 
 <p>
-  <code>(assert <em>expression</em>)</code>
+  <code>(assume <em>expression</em>)</code>
 </p>
   
 The above syntax shall be equivalent to
 <pre>
 (unless <em>expression</em>
-  (fatal-error "assertion failed" (quote <em>expression</em>)))
+  (fatal-error "invalid assumption" (quote <em>expression</em>)))
 </pre>  
 
 Implementations are free to change the exact format of
@@ -247,14 +245,14 @@ the <code><em>message</em></code>, as well as
 any <code><em>obj</em></code>s.
 
 <p>
-  <code>(declare (<em>pred</em> &lt;identifier&gt;))</code>
+  <code>(assume-type <em>pred</em> <em>obj</em>)</code>
 </p>
 
 Here, <em>pred</em> denotes an expression evaluating to a procedure
-accepting one argument.  The syntax shall be equivalent to:
+accepting one argument and <em>obj</em> any Scheme value.  The syntax shall be equivalent to:
 <pre>
-(unless (<em>pred</em> &lt;identifier&gt;)
-  (fatal-error "argument not of expected type" (quote <em>pred</em>) (quote &lt;identifier&gt;)))
+(unless (<em>pred</em> <em>obj</em>)
+  (fatal-error "not of expected type" (quote <em>pred</em>) <em>expr</em>))
 </pre>
 
 Again, implementations are free to change the exact format of
@@ -269,21 +267,23 @@ A simple implementation for R7RS can be given as follows:
 
 <pre>
 (define-library (srfi 145)
-  (export fatal-error assert declare)
+  (export fatal-error assume assume-type)
   (import (scheme base))
   (begin
-    (define-syntax assert
+    (define-syntax assume
       (syntax-rules ()
-        ((assert expression)
+        ((assume expression)
          (unless expression
-           (fatal-error "assertion failed" (quote expression))))
-        ((assert . _)
-         (syntax-error "invalid assert syntax"))))
-    (define-syntax declare
+           (fatal-error "invalid assumption" (quote expression))))
+        ((assume . _)
+         (syntax-error "invalid assume syntax"))))
+    (define-syntax assume-type
       (syntax-rules ()
-        ((declare (pred var)
-         (unless (pred var)
-           (fatal-error "argument not of expected type" (quote pred) (quote var))))))))
+        ((assume-type pred expr
+         (unless (pred expr)
+           (fatal-error "not of expected type" (quote pred) var))))
+        ((assume-type . _)
+         (syntax-error "invalid assume-type syntax"))))
   (cond-expand
     (debug
      (begin
@@ -291,8 +291,8 @@ A simple implementation for R7RS can be given as follows:
     (else
      (begin
        (define (fatal-error message . objs)
-         (car 0))))))
-</pre>  
+         (car 0)))))))
+</pre>
 
 <p>
 This sample implementation meets all the requirements.  If the feature
@@ -311,15 +311,15 @@ the specification given in this SRFI, namely:
 
 <pre>
 (define-library (srfi 145)
-  (export fatal-error assert declare)
+  (export fatal-error assume assume-type)
   (import (scheme base))
   (begin
-    (define-syntax assert
+    (define-syntax assume
       (syntax-rules ()
-        ((assert . _) #f)))
-    (define-syntax declare
+        ((assume . _) #f)))
+    (define-syntax assume-type
       (syntax-rules ()
-        ((declar . _) #f)))
+        ((assume-type . _) #f)))
     (define (fatal-error . args) #f)))
 </pre>
 


### PR DESCRIPTION
This should become the next draft of SRFI 145.

* Renamed assert to assume.
* Renamed declare to assume-type and changed syntax of assume-type slightly.
* Fixed use of cond-expand.
